### PR TITLE
Enhanced MDSL generator to match v5.0 grammar

### DIFF
--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/mdsl/mdsl-api-description.ftl
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/mdsl/mdsl-api-description.ftl
@@ -78,7 +78,7 @@ API provider ${provider.name}
 	<#list provider.endpointOffers as offer>
 	offers ${offer.offeredEndpoint.name}
 	at endpoint location "${offer.location}"
-		via protocol "${offer.protocol}"<#if offer.hasProtocolComment()> // ${offer.getProtocolComment()}</#if>
+		via protocol <#if offer.protocol=="HTTP">${offer.protocol} binding resource Home<#else>"${offer.protocol}"</#if><#if offer.hasProtocolComment()> // ${offer.getProtocolComment()}</#if>
 	</#list>
 </#list>
 


### PR DESCRIPTION
MDSL has protocol binding keywords, HTTP is one of them (see https://microservice-api-patterns.github.io/MDSL-Specification/bindings).  While "HTTP" (in double quotes) validates it does not lead to an actual HTTP binding. Moreover, the syntax of HTTP bindings has changed in MDSL 5, at least one resource has to be defined. 

I extended the ftl template to reflect this. Please check.

In: 
```
	NewContextFromSubdomainsBackend [ PL ] -> [ CF ] NewContextFromSubdomainsFrontend {
		implementationTechnology "HTTP"
		exposedAggregates SD2AggregateBackend
	}
```

Out:
```
API provider NewContextFromSubdomainsBackendProvider
	// This Bounded Context realizes the following subdomains: SD2
	offers SD2AggregateBackend
	at endpoint location "http://localhost:8000"
		via protocol HTTP binding resource Home
```