### PR TITLE
JHipster generation with .ftl: more options, new example

### DIFF
--- a/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Microservices.jdl.ftl
+++ b/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Microservices.jdl.ftl
@@ -11,7 +11,7 @@
 <#-- 
  counter to give microservices different ports 
 -->
-<#assign portCounter = 8083 /> <#-- start later to avoid Windows issues --> 
+<#assign portCounter = 8083 />
 <#-- 
  loop to collect entity data per Bounded Context (BC) and create application plus microservice for each BC
 -->
@@ -51,12 +51,12 @@ microservice ${entityNames?join(", ")} with ${bc.name}<#lt>
 application {
 	config {
 		baseName ${bc.name}
-		packageName ${bc.name?lower_case} <#-- taken out: org.contextmapper.generated. -->
+		packageName ${bc.name?lower_case}
 		applicationType microservice
 		serverPort ${portCounter?int?c}
 		enableSwaggerCodegen true
-		clientFramework react <#-- default not displaying correctly on some hosts -->
-		prodDatabaseType postgresql <#--  to use free Heroku tier (accounts that are not validated) -->
+		clientFramework react
+		prodDatabaseType postgresql
 	}
 	<#if entityNames?has_content>
 	entities ${entityNames?join(", ")}
@@ -90,7 +90,7 @@ application {
 application {
 	config {
 		baseName gateway
-		packageName org.contextmapper.generated.gateway
+		packageName gateway
 		applicationType gateway
 		serverPort 8080
 	}

--- a/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Microservices.jdl.ftl
+++ b/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Microservices.jdl.ftl
@@ -1,0 +1,136 @@
+<#--
+ This template generates a JHipster JDL file.
+ Please consult our online tutorial https://contextmapper.org/docs/jhipster-microservice-generation/ to learn how to use it.
+-->
+<#-- 
+ variables to collect entity names and references: 
+-->
+<#assign allEntityNames = [] />
+<#assign oneToManyRefs = [] />
+<#assign oneToOneRefs = [] />
+<#-- 
+ counter to give microservices different ports 
+-->
+<#assign portCounter = 8083 /> <#-- start later to avoid Windows issues --> 
+<#-- 
+ loop to collect entity data per Bounded Context (BC) and create application plus microservice for each BC
+-->
+<#list filterStructuralBoundedContexts(boundedContexts) as bc>
+<#assign entities = [] />
+<#assign entityNames = [] />
+<#list bc.aggregates as agg>
+	<#assign entities = entities + agg.domainObjects?filter(dob -> instanceOf(dob, Entity) || instanceOf(dob, ValueObject))>
+</#list>
+<#assign entityNames = entities?map(e -> e.name)>
+<#assign allEntityNames = allEntityNames + entityNames>
+<#if entities?has_content>
+
+/* Bounded Context ${bc.name} */<#lt>
+<#list entities as entity>
+
+entity ${entity.name} {
+<#list entity.attributes as attribute>
+	${attribute.name} ${mapAttributeType(attribute.type)}
+</#list>
+}
+<#list entity.references as reference>
+	<#if reference.domainObjectType?has_content && (instanceOf(reference.domainObjectType, Entity) || instanceOf(reference.domainObjectType, ValueObject)) && entityNames?seq_contains(reference.domainObjectType.name)>
+		<#if reference.collectionType?has_content && reference.collectionType.name() != "NONE">
+			<#assign oneToManyRefs = oneToManyRefs + [ entity.name + "{" + reference.name + "} to " + reference.domainObjectType.name ]>
+		<#else>
+			<#assign oneToOneRefs = oneToOneRefs + [ entity.name + "{"+ reference.name + "} to " + reference.domainObjectType.name ]>
+		</#if>
+	</#if>
+</#list>
+
+</#list>
+microservice ${entityNames?join(", ")} with ${bc.name}<#lt>
+</#if>
+
+<#assign portCounter++ />
+application {
+	config {
+		baseName ${bc.name}
+		packageName ${bc.name?lower_case} <#-- taken out: org.contextmapper.generated. -->
+		applicationType microservice
+		serverPort ${portCounter?int?c}
+		enableSwaggerCodegen true
+		clientFramework react <#-- default not displaying correctly on some hosts -->
+		prodDatabaseType postgresql <#--  to use free Heroku tier (accounts that are not validated) -->
+	}
+	<#if entityNames?has_content>
+	entities ${entityNames?join(", ")}
+	</#if>
+}
+</#list>
+
+<#--
+ here we print the collected references as relationships:
+-->
+/* relationships */
+<#if oneToManyRefs?has_content>
+	relationship OneToMany {<#lt>
+		<#list oneToManyRefs as reference>
+			${reference}
+		</#list>
+	}<#lt>
+</#if>
+<#if oneToOneRefs?has_content>
+	relationship OneToOne {<#lt>
+		<#list oneToOneRefs as reference>
+			${reference}
+		</#list>
+	}<#lt>
+</#if>
+
+<#--
+ create a microservice gateway (user interface)
+-->
+/* microservice gateway app */
+application {
+	config {
+		baseName gateway
+		packageName org.contextmapper.generated.gateway
+		applicationType gateway
+		serverPort 8080
+	}
+	<#if allEntityNames?has_content>
+	entities ${allEntityNames?join(", ")}
+	</#if>
+}
+
+<#--
+ additional configurations for the JHipster generator:
+-->
+/* additional options */
+dto * with mapstruct
+service * with serviceImpl
+
+<#-- Data type mapping: -->
+<#function mapAttributeType inputType>
+  <#if inputType == "String">
+  	<#return "String">
+  <#elseif inputType == "int" || inputType == "Integer">
+  	<#return "Integer">
+  <#elseif inputType == "long" || inputType == "Long">
+  	<#return "Long">
+  <#elseif inputType == "boolean" || inputType == "Boolean">
+  	<#return "Boolean">
+  <#elseif inputType == "Date" || inputType == "DateTime" || inputType == "Timestamp">
+  	<#return "LocalDate">
+  <#elseif inputType == "BigDecimal" || inputType == "BigInteger">
+  	<#return "BigDecimal">
+  <#elseif inputType == "double" || inputType == "Double">
+  	<#return "Double">
+  <#elseif inputType == "float" || inputType == "Float">
+  	<#return "Float">
+  <#elseif inputType == "Key">
+  	<#return "UUID">
+  <#elseif inputType == "Blob" || inputType =="Object[]">
+  	<#return "Blob">
+  <#elseif inputType == "Clob">
+  	<#return "TextBlob">
+  <#else>
+  	<#return "Blob">
+  </#if>
+</#function>

--- a/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Monolith.jdl.ftl
+++ b/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Monolith.jdl.ftl
@@ -1,0 +1,114 @@
+<#--
+ This template generates a JHipster JDL file, monolith configuration
+ Please consult our online tutorial https://contextmapper.org/docs/jhipster-microservice-generation/ to learn how to use it.
+-->
+<#-- 
+ variables to collect entity names and references: 
+-->
+<#assign allEntityNames = [] />
+<#assign oneToManyRefs = [] />
+<#assign oneToOneRefs = [] />
+
+<#-- 
+ loop to collect entity data per Bounded Context (BC) and create application plus microservice for each BC
+-->
+<#list filterStructuralBoundedContexts(boundedContexts) as bc>
+<#assign entities = [] />
+<#assign entityNames = [] />
+<#list bc.aggregates as agg>
+	<#assign entities = entities + agg.domainObjects?filter(dob -> instanceOf(dob, Entity) || instanceOf(dob, ValueObject))>
+</#list>
+<#assign entityNames = entities?map(e -> e.name)>
+<#assign allEntityNames = allEntityNames + entityNames>
+<#if entities?has_content>
+
+/* Bounded Context ${bc.name} */<#lt>
+<#list entities as entity>
+
+entity ${entity.name} {
+<#list entity.attributes as attribute>
+	${attribute.name} ${mapAttributeType(attribute.type)}
+</#list>
+}
+<#list entity.references as reference>
+	<#if reference.domainObjectType?has_content && (instanceOf(reference.domainObjectType, Entity) || instanceOf(reference.domainObjectType, ValueObject)) && entityNames?seq_contains(reference.domainObjectType.name)>
+		<#if reference.collectionType?has_content && reference.collectionType.name() != "NONE">
+			<#assign oneToManyRefs = oneToManyRefs + [ entity.name + "{" + reference.name + "} to " + reference.domainObjectType.name ]>
+		<#else>
+			<#assign oneToOneRefs = oneToOneRefs + [ entity.name + "{"+ reference.name + "} to " + reference.domainObjectType.name ]>
+		</#if>
+	</#if>
+</#list>
+</#list>
+</#if>
+</#list>
+
+application {
+	config {
+		baseName BoundedContextsMonolith // TODO define for your project
+		packageName to.doo.pick.one // TODO define for your project
+		applicationType monolith
+		serverPort 8080
+		enableSwaggerCodegen true
+		clientFramework react <#-- default not displaying correctly on some hosts -->
+		prodDatabaseType postgresql <#--  to use free Heroku tier (accounts that are not validated) -->
+	}
+	<#if allEntityNames?has_content>
+	entities ${allEntityNames?join(", ")}
+	</#if>
+}
+
+<#--
+ here we print the collected references as relationships:
+-->
+/* relationships */
+<#if oneToManyRefs?has_content>
+	relationship OneToMany {<#lt>
+		<#list oneToManyRefs as reference>
+			${reference}
+		</#list>
+	}<#lt>
+</#if>
+<#if oneToOneRefs?has_content>
+	relationship OneToOne {<#lt>
+		<#list oneToOneRefs as reference>
+			${reference}
+		</#list>
+	}<#lt>
+</#if>
+
+<#--
+ additional configurations for the JHipster generator:
+-->
+/* additional options */
+dto * with mapstruct
+service * with serviceImpl
+
+<#-- Data type mapping: -->
+<#function mapAttributeType inputType>
+  <#if inputType == "String">
+  	<#return "String">
+  <#elseif inputType == "int" || inputType == "Integer">
+  	<#return "Integer">
+  <#elseif inputType == "long" || inputType == "Long">
+  	<#return "Long">
+  <#elseif inputType == "boolean" || inputType == "Boolean">
+  	<#return "Boolean">
+  <#elseif inputType == "Date" || inputType == "DateTime" || inputType == "Timestamp">
+  	<#return "LocalDate">
+  <#elseif inputType == "BigDecimal" || inputType == "BigInteger">
+  	<#return "BigDecimal">
+  <#elseif inputType == "double" || inputType == "Double">
+  	<#return "Double">
+  <#elseif inputType == "float" || inputType == "Float">
+  	<#return "Float">
+  <#elseif inputType == "Key">
+  	<#return "UUID">
+  <#elseif inputType == "Blob" || inputType =="Object[]">
+  	<#return "Blob">
+  <#elseif inputType == "Clob">
+  	<#return "TextBlob">
+  <#else>
+  	<#return "Blob">
+  </#if>
+</#function>

--- a/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Monolith.jdl.ftl
+++ b/org.contextmapper.dsl.ui/samples/freemarker/jhipster/JHipster-Monolith.jdl.ftl
@@ -50,8 +50,8 @@ application {
 		applicationType monolith
 		serverPort 8080
 		enableSwaggerCodegen true
-		clientFramework react <#-- default not displaying correctly on some hosts -->
-		prodDatabaseType postgresql <#--  to use free Heroku tier (accounts that are not validated) -->
+		clientFramework react
+		prodDatabaseType postgresql
 	}
 	<#if allEntityNames?has_content>
 	entities ${allEntityNames?join(", ")}

--- a/org.contextmapper.dsl.ui/samples/freemarker/sample-models/OnlineShopScenario.cml
+++ b/org.contextmapper.dsl.ui/samples/freemarker/sample-models/OnlineShopScenario.cml
@@ -1,0 +1,132 @@
+// note: no context map in this example (by intent)
+
+BoundedContext OnlineShopFeatures implements BusinessToConsumer {
+	domainVisionStatement "This Bounded Context realizes the following subdomains: BusinessToConsumer"
+	type FEATURE
+
+	Aggregate OrderAggregate {
+		Service UC2BrowseAndBuyService {
+			Set<@Product> readProduct (Set<@ProductId> productId);
+			@OrderId createOrder (@Order order);
+			@OrderItemId createOrderItem (@OrderItem orderItem);
+		}
+		ValueObject OrderId {
+			Long orderId
+		}
+		ValueObject OrderItemId {
+			Long orderitemId
+		}
+		Entity Order {
+			String orderNumber
+			- List<OrderItem> orderitemList
+			- OrderId orderId
+		}
+	}
+	Aggregate OrderItemAggregate {
+		Entity OrderItem {
+			aggregateRoot
+			String productName
+			String price
+			- OrderItemId orderitemId
+		}
+	}
+}
+
+BoundedContext ProductContext {
+	// type FEATURE could be derived/defined during refactoring
+	Aggregate ProductCatalogAggregate {
+		Entity ProductCatalog {
+			aggregateRoot
+			- ProductCatalogId productcatalogId
+			- List<Product> productList
+		}
+		ValueObject ProductCatalogId {
+			Long productcatalogId
+		}
+		Entity Product {
+			String productName
+			String image
+			String productCategory
+			- ProductId productId
+		}
+		ValueObject ProductId {
+			Long productId
+		}
+	}
+}
+
+BoundedContext CustomerContext {
+	Aggregate CustomerAggregate {
+		Service UC1RegisterService {
+			@CustomerAccountId createCustomerAccount (@CustomerAccount customerAccount);
+		}
+		Entity CustomerAccount {
+			aggregateRoot
+			String name
+			String address
+			- CustomerAccountId customeraccountId
+		}
+		ValueObject CustomerAccountId {
+			Long customeraccountId
+		}
+	}
+}
+
+Domain ECommerce {
+	Subdomain BusinessToConsumer supports UC1Register , UC2BrowseAndBuy {
+		domainVisionStatement "Aims at promoting the following benefit for a OnlineShopper: shop online and do not have to leave home; Aims at promoting the following benefit for a OnlineShopper: get best price"
+		Entity CustomerAccount {
+			String name
+			String address
+		}
+		Entity Product {
+			String productName
+			String image
+			String productCategory
+		}
+		Entity ProductCatalog {
+			- List<Product> productList
+		}
+		Entity Order {
+			String orderNumber
+			- List<OrderItem> orderitemList
+		}
+		Entity OrderItem {
+			String productName
+			String price
+		}
+		Service UC1RegisterService {
+			createCustomerAccount;
+		}
+		Service UC2BrowseAndBuyService {
+			readProduct;
+			createOrder;
+			createOrderItem;
+		}
+	}
+
+}
+
+UseCase UC1Register {
+	actor = "OnlineShopper"
+	interactions =
+	create a "CustomerAccount" with its "Name", "Address"
+	benefit "shop online and do not have to leave home"
+}
+
+UseCase UC1Ads {
+	actor = "OnlineShopper2"
+	interactions =
+	"add" a "CustomerAccount" to a "CustomerCollection"
+	benefit "shop online and do not have to leave home"
+}
+
+UseCase UC2BrowseAndBuy {
+	actor = "OnlineShopper"
+	interactions =
+	read a "Product" with its "productName", "image", "productCategory" in a "ProductCatalog",
+	create an "Order" with its "OrderNumber",
+	create an "OrderItem" with its "productName", "price" in an "Order"
+	benefit "get best price"
+}
+


### PR DESCRIPTION
Simplifies usage of generated .jdl files (less processes to be started, ports not occupied by some services on Windows) and makes resulting applications deployable on Heroku w/o further tweaking (when using free plan, no credit card on file).   

The new online shop example is not really needed but demonstrates difference between micoservices and modulith better than the reference management demo featured in the demo instructions:

- (shorter version, new) https://medium.com/olzzio/domain-driven-service-design-with-context-mapper-and-mdsl-d5a0fc6091c2
- (long version, updated): https://ozimmer.ch/practices/2020/06/10/ICWEKeynoteAndDemo.html