### PR TITLE
Enhancing HTTP binding of MDSL generator

### DIFF
--- a/org.contextmapper.dsl.tests/integ-test-files/mdsl/mdsl-http-binding.cml
+++ b/org.contextmapper.dsl.tests/integ-test-files/mdsl/mdsl-http-binding.cml
@@ -1,0 +1,44 @@
+ContextMap SampleMapWithHTTPRelationship {
+	contains ClientContext
+	contains ProviderContext
+
+	ClientContext [D]<-[U, OHS, PL] ProviderContext {
+		exposedAggregates=SampleAggregate
+		implementationTechnology="HTTP"
+	}
+}
+
+BoundedContext ClientContext
+
+BoundedContext ProviderContext {
+	Aggregate SampleAggregate {
+		Service MAPPatterns {
+			"STATE_CREATION_OPERATION" boolean testOpA(String str);
+			"STATE_TRANSITION_OPERATION" boolean testOpB(String str);
+			"RETRIEVAL_OPERATION" boolean testOpC(String str);
+			"COMPUTATION_FUNCTION" boolean testOpD(String str);
+		}
+		// note: entities and services must not contain operations with the same names
+		Service VerbHeuristics {
+			String createSomething();
+			String updateSomething(int i);
+			String readSomething(int i);
+			String getSomething(int i);
+			deleteSomething(int i);
+		}
+		Entity DirectVerbMappings {
+			aggregateRoot
+			"PUT" def boolean testOp1(String str);
+			"POST" def boolean testOp2(String str);
+			"PATCH" def boolean testOp3(String str);
+			"GET" def boolean testOp4(String str);
+			"DELETE" def boolean testOp5(String str);
+			"OPTIONS" def boolean testOp6(String str);
+			"HEAD" def boolean testOp7(String str);
+		}
+		Service OtherOptions {
+			"OTHER" boolean testOp9(String str);
+			boolean testOp10(String str); // no doc string
+		}
+	}
+}

--- a/org.contextmapper.dsl.tests/integ-test-files/mdsl/mdsl-http-binding.mdsl
+++ b/org.contextmapper.dsl.tests/integ-test-files/mdsl/mdsl-http-binding.mdsl
@@ -1,0 +1,139 @@
+// Generated from DDD Context Map.
+API description ProviderContextAPI
+usage context PUBLIC_API for BACKEND_INTEGRATION and FRONTEND_INTEGRATION
+
+
+
+
+endpoint type SampleAggregate
+	exposes
+		operation testOp1
+			with responsibility "PUT"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOp2
+			with responsibility "POST"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOp3
+			with responsibility "PATCH"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOp4
+			with responsibility "GET"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOp5
+			with responsibility "DELETE"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOp6
+			with responsibility "OPTIONS"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOp7
+			with responsibility "HEAD"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOpA
+			with responsibility STATE_CREATION_OPERATION
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOpB
+			with responsibility STATE_TRANSITION_OPERATION
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOpC
+			with responsibility RETRIEVAL_OPERATION
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOpD
+			with responsibility COMPUTATION_FUNCTION
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation createSomething
+			expecting
+				payload D<void>
+			delivering
+				payload D<string>
+		operation updateSomething
+			expecting
+				payload D<int>
+			delivering
+				payload D<string>
+		operation readSomething
+			expecting
+				payload D<int>
+			delivering
+				payload D<string>
+		operation getSomething
+			expecting
+				payload D<int>
+			delivering
+				payload D<string>
+		operation deleteSomething
+			expecting
+				payload D<int>
+		operation testOp9
+			with responsibility "OTHER"
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+		operation testOp10
+			expecting
+				payload D<string>
+			delivering
+				payload D<bool>
+
+
+// Generated from DDD upstream Bounded Context 'ProviderContext' implementing OPEN_HOST_SERVICE (OHS) and PUBLISHED_LANGUAGE (PL).
+API provider ProviderContextProvider
+	offers SampleAggregate
+	at endpoint location "http://localhost:8000"
+		via protocol HTTP binding resource SampleAggregateHome at "/SampleAggregate"
+			operation testOp1 to PUT	
+			operation testOp2 to POST
+			operation testOp3 to PATCH	
+			operation testOp4 to GET
+			operation testOp5 to DELETE	
+			operation testOp6 to OPTIONS	
+			operation testOp7 to HEAD		
+			operation testOpA to PUT
+			operation testOpB to PATCH
+			operation testOpC to GET
+			operation testOpD to POST
+			operation createSomething to POST
+			operation updateSomething to PATCH
+			operation readSomething to GET
+			operation getSomething to GET
+			operation deleteSomething to DELETE
+			operation testOp9 to POST // TODO map OTHER
+			operation testOp10 to POST
+
+
+
+API client ClientContextClient
+	consumes SampleAggregate

--- a/org.contextmapper.dsl.tests/src/org/contextmapper/dsl/generators/mdsl/MDSLAPIDescriptionCreatorTest.java
+++ b/org.contextmapper.dsl.tests/src/org/contextmapper/dsl/generators/mdsl/MDSLAPIDescriptionCreatorTest.java
@@ -241,6 +241,11 @@ public class MDSLAPIDescriptionCreatorTest extends AbstractCMLInputFileTest {
 			testCMLInputAndMDSLOutputFiles("mdsl-nothing-to-generate-test-2");
 		});
 	}
+	
+	@Test
+	void canGenerateHTTPBindingMachtingImplementationTechnologyOfMapRelation() throws IOException {
+		testCMLInputAndMDSLOutputFiles("mdsl-http-binding");
+	}
 
 	private void testCMLInputAndMDSLOutputFiles(String baseFilename) throws IOException {
 		testCMLInputAndMDSLOutputFiles(baseFilename, false);

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/mdsl/mdsl-api-description.ftl
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/mdsl/mdsl-api-description.ftl
@@ -1,3 +1,46 @@
+<#macro opbind opname oprespo>
+<#if opname?starts_with("create")>
+			operation ${opname} to POST
+<#elseif opname?starts_with("replace")>
+			operation ${opname} to PUT
+<#elseif opname?starts_with("update")>
+			operation ${opname} to PATCH
+<#elseif opname?starts_with("get")>
+			operation ${opname} to GET
+<#elseif opname?starts_with("lookup")>
+			operation ${opname} to GET
+<#elseif opname?starts_with("retrieve")>
+			operation ${opname} to GET
+<#elseif opname?starts_with("read")>
+			operation ${opname} to GET
+<#elseif opname?starts_with("delete")>
+			operation ${opname} to DELETE
+<#elseif oprespo=="RETRIEVAL_OPERATION">
+			operation ${opname} to GET
+<#elseif oprespo=="STATE_CREATION_OPERATION">
+			operation ${opname} to PUT
+<#elseif oprespo=="STATE_TRANSITION_OPERATION">
+			operation ${opname} to PATCH
+<#elseif oprespo=="COMPUTATION_FUNCTION">
+			operation ${opname} to POST
+<#elseif oprespo=="GET">
+			operation ${opname} to GET
+<#elseif oprespo=="POST">
+			operation ${opname} to POST
+<#elseif oprespo=="PUT">
+			operation ${opname} to PUT	
+<#elseif oprespo=="DELETE">
+			operation ${opname} to DELETE	
+<#elseif oprespo=="PATCH">
+			operation ${opname} to PATCH	
+<#elseif oprespo=="HEAD">
+			operation ${opname} to HEAD		
+<#elseif oprespo=="OPTIONS">
+			operation ${opname} to OPTIONS	
+<#else>		
+			operation ${opname} to POST // TODO map ${oprespo}
+</#if>
+</#macro>
 <#if timestampString?has_content>
 // ${timestampString}
 </#if>
@@ -78,7 +121,8 @@ API provider ${provider.name}
 	<#list provider.endpointOffers as offer>
 	offers ${offer.offeredEndpoint.name}
 	at endpoint location "${offer.location}"
-		via protocol <#if offer.protocol=="HTTP">${offer.protocol} binding resource Home<#else>"${offer.protocol}"</#if><#if offer.hasProtocolComment()> // ${offer.getProtocolComment()}</#if>
+		via protocol <#if offer.protocol=="HTTP">${offer.protocol} binding resource ${offer.offeredEndpoint.name}Home at "/${offer.offeredEndpoint.name}"
+<#list offer.offeredEndpoint.operations as operation><@opbind opname=operation.name oprespo=operation.endpointResponsibility!"POST"/></#list><#else>"${offer.protocol}"</#if><#if offer.hasProtocolComment()> // ${offer.getProtocolComment()}</#if>
 	</#list>
 </#list>
 


### PR DESCRIPTION
A complete MDSL-to-HTTP binding is now generated when "HTTP" is the implementation technology of a relation in a context map whose upstream exposes aggregates with at least one service or root entity operation, including a resource and operation bindings. Three heuristics to identify HTTP verbs, two of which work with doc string (MAP decorator, explicit verb name).