### PR TITLE
Improve generated plantuml diagrams

### DIFF
--- a/org.contextmapper.dsl.tests/integ-test-files/plantuml/associations.cml
+++ b/org.contextmapper.dsl.tests/integ-test-files/plantuml/associations.cml
@@ -1,0 +1,57 @@
+BoundedContext CustomerManagementContext {
+	
+	Aggregate Customers {
+		Entity Customer {
+			aggregateRoot
+			
+            - @Address address nullable
+			- List<@City> cities
+			- List<@City> towns size="min=1,max=4"
+			- List<@Order> orders
+			- @Thing thing -- "things"
+
+			* void anotherMethod(@Name name);
+			* @ReturnTypeEntity createReturnTypeEntity();
+
+			-- "lives at" @Address
+			-- "uses >" @Name
+			-- "creates >" @ReturnTypeEntity
+		}
+		
+		Entity Address {
+			- @City city
+			String name
+		}
+
+		ValueObject City {
+			String name
+		}
+
+        ValueObject Name {
+            String first
+            String last
+        }
+
+		Entity ReturnTypeEntity {
+			int i
+		}
+
+		Entity ManyToManyFirst {
+			- List<@ManyToManySecond> seconds -- "interact"
+		}
+
+		Entity ManyToManySecond {
+			- List<@ManyToManyFirst> firsts	-- "interact"
+		}
+
+		Entity Thing {
+			int i
+		}
+	}
+
+	Aggregate Orders {
+		Entity Order {
+			String something
+		}
+	}
+}

--- a/org.contextmapper.dsl.tests/src/org/contextmapper/dsl/TacticDDDAssociatonsGrammarTest.xtend
+++ b/org.contextmapper.dsl.tests/src/org/contextmapper/dsl/TacticDDDAssociatonsGrammarTest.xtend
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 The Context Mapper Project Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.contextmapper.dsl
+
+import com.google.inject.Inject
+import org.contextmapper.dsl.contextMappingDSL.ContextMappingModel
+import org.contextmapper.dsl.tests.ContextMappingDSLInjectorProvider
+import org.contextmapper.tactic.dsl.tacticdsl.DomainObject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.extensions.InjectionExtension
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.eclipse.xtext.testing.validation.ValidationTestHelper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.^extension.ExtendWith
+
+import static org.contextmapper.dsl.util.ParsingErrorAssertions.*
+import static org.junit.jupiter.api.Assertions.*
+import org.contextmapper.tactic.dsl.tacticdsl.TacticdslPackage
+
+@ExtendWith(InjectionExtension)
+@InjectWith(ContextMappingDSLInjectorProvider)
+class TacticDDDAssociatonsGrammarTest {
+	@Inject
+	ParseHelper<ContextMappingModel> parseHelper
+
+	ValidationTestHelper validationTestHelper = new ValidationTestHelper();
+
+	@Test
+	def void canDefineAssociationBetweenDomainObjects() {
+		// given
+		val String dslSnippet = '''
+			BoundedContext TestContext {
+				Aggregate TestAggregate {
+					Entity Customer {
+						-- "lives at" @Address
+					}
+					
+					Entity Address
+				}
+			}
+		''';
+
+		// when
+		val ContextMappingModel result = parseHelper.parse(dslSnippet);
+		val DomainObject customer = result.boundedContexts.get(0).aggregates.get(0).domainObjects.get(0) as DomainObject;
+
+		// then
+		assertThatNoParsingErrorsOccurred(result);
+		assertThatNoValidationErrorsOccurred(result);
+		assertEquals(1, customer.associations.size);
+		assertEquals("lives at", customer.associations.get(0).description);
+		assertEquals("Address", customer.associations.get(0).domainObjectType.name);
+	}
+	
+	@Test
+	def void canDefineAssociationLabelOnReference() {
+		// given
+		val String dslSnippet = '''
+			BoundedContext TestContext {
+				Aggregate TestAggregate {
+					Entity Customer {
+						- @Address address -- "address"
+					}
+					
+					Entity Address
+				}
+			}
+		''';
+
+		// when
+		val ContextMappingModel result = parseHelper.parse(dslSnippet);
+		val DomainObject customer = result.boundedContexts.get(0).aggregates.get(0).domainObjects.get(0) as DomainObject;
+
+		// then
+		assertThatNoParsingErrorsOccurred(result);
+		assertThatNoValidationErrorsOccurred(result);
+		assertEquals(1, customer.references.size);
+		assertEquals("address", customer.references.get(0).associationLabel);
+	}
+	
+	@Test
+	def void cannotDefineAssociationFromBCToSubdomain() {
+		// given
+		val String dslSnippet = '''
+			BoundedContext TestContext {
+				Aggregate TestAggregate {
+					Entity Customer {
+						-- "lives at" @Address
+					}
+				}
+			}
+			
+			Domain TestDomain {
+				Subdomain TestSubdomain {
+					Entity Address
+				}
+			}
+		''';
+
+		// when
+		val ContextMappingModel result = parseHelper.parse(dslSnippet);
+
+		// then
+		assertThatNoParsingErrorsOccurred(result);
+		this.validationTestHelper.assertError(result, TacticdslPackage.Literals.ASSOCIATION, "org.eclipse.xtext.diagnostics.Diagnostic.Linking", 
+        	"Couldn't resolve reference to SimpleDomainObject 'Address'.");
+	}
+	
+	@Test
+	def void cannotDefineAssociationFromSubdomainToBC() {
+		// given
+		val String dslSnippet = '''
+			BoundedContext TestContext {
+				Aggregate TestAggregate {
+					Entity Address
+				}
+			}
+			
+			Domain TestDomain {
+				Subdomain TestSubdomain {
+					Entity Customer {
+						-- "lives at" @Address
+					}
+				}
+			}
+		''';
+
+		// when
+		val ContextMappingModel result = parseHelper.parse(dslSnippet);
+
+		// then
+		assertThatNoParsingErrorsOccurred(result);
+		this.validationTestHelper.assertError(result, TacticdslPackage.Literals.ASSOCIATION, "org.eclipse.xtext.diagnostics.Diagnostic.Linking", 
+        	"Couldn't resolve reference to SimpleDomainObject 'Address'.");
+	}
+
+}

--- a/org.contextmapper.dsl.tests/src/org/contextmapper/dsl/generators/plantuml/AssociationLinkTest.java
+++ b/org.contextmapper.dsl.tests/src/org/contextmapper/dsl/generators/plantuml/AssociationLinkTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 The Context Mapper Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.contextmapper.dsl.generators.plantuml;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.contextmapper.dsl.generator.plantuml.AssociationLink;
+import org.junit.jupiter.api.Test;
+
+class AssociationLinkTest {
+
+	@Test
+	void isEqualIfParticipantsAreTheSame() {
+		// given
+		AssociationLink link1 = new AssociationLink("participant1", "participant2", "label");
+		AssociationLink link2 = new AssociationLink("participant1", "participant2", "label");
+
+		// when
+		boolean isEqual = link1.equals(link2);
+
+		// then
+		assertTrue(isEqual);
+	}
+
+	@Test
+	void isEqualIfParticipantsAreSameButSwitched() {
+		// given
+		AssociationLink link1 = new AssociationLink("participant1", "participant2", "label");
+		AssociationLink link2 = new AssociationLink("participant2", "participant1", "label");
+
+		// when
+		boolean isEqual = link1.equals(link2);
+
+		// then
+		assertTrue(isEqual);
+	}
+
+	@Test
+	void isNotEqualIfLabelIsDifferent1() {
+		// given
+		AssociationLink link1 = new AssociationLink("participant1", "participant2", "label");
+		AssociationLink link2 = new AssociationLink("participant1", "participant2", "otherLabel");
+
+		// when
+		boolean isEqual = link1.equals(link2);
+
+		// then
+		assertFalse(isEqual);
+	}
+	
+	@Test
+	void isNotEqualIfLabelIsDifferent2() {
+		// given
+		AssociationLink link1 = new AssociationLink("participant1", "participant2", "label");
+		AssociationLink link2 = new AssociationLink("participant2", "participant1", "otherLabel");
+
+		// when
+		boolean isEqual = link1.equals(link2);
+
+		// then
+		assertFalse(isEqual);
+	}
+
+	@Test
+	void isNotEqualIfOtherObjectIsNull() {
+		// given
+		AssociationLink link = new AssociationLink("participant1", "participant2", "label");
+
+		// when
+		boolean isEqual = link.equals(null);
+
+		// then
+		assertFalse(isEqual);
+	}
+
+	@Test
+	void isNotEqualIfOtherObjectIsOfOtherType() {
+		// given
+		AssociationLink link = new AssociationLink("participant1", "participant2", "label");
+
+		// when
+		boolean isEqual = link.equals(new Object());
+
+		// then
+		assertFalse(isEqual);
+	}
+
+	@Test
+	void isEqualIfOtherObjectIsSameRef() {
+		// given
+		AssociationLink link = new AssociationLink("participant1", "participant2", "label");
+
+		// when
+		boolean isEqual = link.equals(link);
+
+		// then
+		assertTrue(isEqual);
+	}
+
+	@Test
+	void isSelfReferenceIfNamesAreEqual() {
+		// given
+		AssociationLink link = new AssociationLink("participant1", "participant1", "label");
+
+		// when
+		boolean isSelfReference = link.isSelfReference();
+
+		// then
+		assertTrue(isSelfReference);
+	}
+
+	@Test
+	void isNoSelfReferenceIfNamesAreNotEqual() {
+		// given
+		AssociationLink link = new AssociationLink("participant1", "participant2", "label");
+
+		// when
+		boolean isSelfReference = link.isSelfReference();
+
+		// then
+		assertFalse(isSelfReference);
+	}
+
+}

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AbstractPlantUMLClassDiagramCreator.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AbstractPlantUMLClassDiagramCreator.java
@@ -16,9 +16,12 @@
 package org.contextmapper.dsl.generator.plantuml;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.contextmapper.dsl.contextMappingDSL.Aggregate;
 import org.contextmapper.dsl.contextMappingDSL.SculptorModule;
+import org.contextmapper.tactic.dsl.tacticdsl.Association;
 import org.contextmapper.tactic.dsl.tacticdsl.Attribute;
 import org.contextmapper.tactic.dsl.tacticdsl.CollectionType;
 import org.contextmapper.tactic.dsl.tacticdsl.CommandEvent;
@@ -42,19 +45,23 @@ import com.google.common.collect.Lists;
 
 abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> extends AbstractPlantUMLDiagramCreator<T> {
 
-	protected List<UMLRelationship> relationships;
+	protected Map<AssociationLink, AssociationInfo> associationInfos;
 	protected List<UMLRelationship> extensions;
 	protected List<SimpleDomainObject> domainObjects;
 
 	protected void printDomainObject(SimpleDomainObject domainObject, int indentation) {
+		printDomainObject(null, domainObject, indentation);
+	}
+
+	protected void printDomainObject(Aggregate aggregate, SimpleDomainObject domainObject, int indentation) {
 		if (domainObject instanceof Enum)
 			printEnum((Enum) domainObject, indentation);
 		else if (domainObject instanceof Entity)
-			printEntity((Entity) domainObject, indentation);
+			printEntity(aggregate, (Entity) domainObject, indentation);
 		else if (domainObject instanceof Event)
-			printEvent((Event) domainObject, indentation);
+			printEvent(aggregate, (Event) domainObject, indentation);
 		else if (domainObject instanceof ValueObject)
-			printValueObject((ValueObject) domainObject, indentation);
+			printValueObject(aggregate, (ValueObject) domainObject, indentation);
 	}
 
 	protected void printModule(SculptorModule module) {
@@ -83,10 +90,10 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 		sb.append("package ").append("\"'").append(aggregate.getName()).append("' ").append("Aggregate\"").append(" <<Rectangle>> ").append("{");
 		linebreak();
 		for (SimpleDomainObject domainObject : aggregate.getDomainObjects()) {
-			printDomainObject(domainObject, indentation + 1);
+			printDomainObject(aggregate, domainObject, indentation + 1);
 		}
 		for (Service service : aggregate.getServices()) {
-			printService(service, indentation + 1);
+			printService(aggregate, service, indentation + 1);
 		}
 		printIndentation(indentation);
 		sb.append("}");
@@ -94,12 +101,17 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 	}
 	
 	protected void printService(Service service, int indentation) {
+		printService(null, service, indentation);
+	}
+
+	protected void printService(Aggregate aggregate, Service service, int indentation) {
 		printIndentation(indentation);
 		sb.append("class").append(" ").append(service.getName());
 		sb.append(" <<(S,DarkSeaGreen) Service>> ");
 		sb.append("{");
 		linebreak();
 		printServiceOperations(service.getName(), service.getOperations(), indentation + 1);
+		processAssociations(aggregate, service.getName(), service.getAssociations());
 		printIndentation(indentation);
 		sb.append("}");
 		linebreak();
@@ -123,25 +135,24 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 		printIndentation(indentation);
 		sb.append("}");
 		linebreak();
-	}
-	
+	}	
 
-	private void printEntity(Entity entity, int indentation) {
-		printStereotypedClass("(E,DarkSeaGreen) Entity", entity, indentation);
-	}
-
-	private void printValueObject(ValueObject valueObject, int indentation) {
-		printStereotypedClass("(V,DarkSeaGreen) Value Object", valueObject, indentation);
+	private void printEntity(Aggregate aggregate, Entity entity, int indentation) {
+		printStereotypedClass(aggregate, "(E,DarkSeaGreen) Entity", entity, indentation);
 	}
 
-	private void printEvent(Event event, int indentation) {
+	private void printValueObject(Aggregate aggregate, ValueObject valueObject, int indentation) {
+		printStereotypedClass(aggregate, "(V,DarkSeaGreen) Value Object", valueObject, indentation);
+	}
+
+	private void printEvent(Aggregate aggregate, Event event, int indentation) {
 		if (event instanceof CommandEvent)
-			printStereotypedClass("(C,#3bc5e9) Command", event, indentation);
+			printStereotypedClass(aggregate, "(C,#3bc5e9) Command", event, indentation);
 		else if (event instanceof DomainEvent)
-			printStereotypedClass("(E,#ff9f4b) Domain Event", event, indentation);
+			printStereotypedClass(aggregate, "(E,#ff9f4b) Domain Event", event, indentation);
 	}
 
-	private void printStereotypedClass(String stereotype, DomainObject object, int indentation) {
+	private void printStereotypedClass(Aggregate aggregate, String stereotype, DomainObject object, int indentation) {
 		printIndentation(indentation);
 		sb.append("class").append(" ").append(object.getName());
 		if (object.isAggregateRoot())
@@ -153,12 +164,15 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 		printAttributes(object.getAttributes(), indentation + 1);
 		printReferenceAttributes(object.getReferences(), indentation + 1);
 
-		addReferences2List(object, object.getReferences());
+		processReferencesAsAssociations(aggregate, object, object.getReferences());
 
 		printDomainObjectOperations(object.getName(), object.getOperations(), indentation + 1);
 		printIndentation(indentation);
 		sb.append("}");
 		linebreak();
+
+		processAssociations(aggregate, object.getName(), object.getAssociations());
+
 		if (object.getExtendsName() != null && !"".equals(object.getExtendsName()))
 			addExtensionToList(object.getName(), object.getExtendsName());
 		else if (object instanceof Entity && ((Entity) object).getExtends() != null)
@@ -171,21 +185,104 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 			addExtensionToList(object.getName(), ((ValueObject) object).getExtends());
 	}
 
-	private void addReferences2List(SimpleDomainObject sourceDomainObject, List<Reference> references) {
-		for (Reference reference : references) {
-			if (reference.getCollectionType() != null && reference.getCollectionType() != CollectionType.NONE)
-				addDomainObjectReference2List(sourceDomainObject.getName(), reference.getDomainObjectType(), reference.getName(), ClassRelationType.AGGREGATION);
-			else
-				addDomainObjectReference2List(sourceDomainObject.getName(), reference.getDomainObjectType(), reference.getName(), ClassRelationType.DEFAULT);
+	private void processAssociations(Aggregate aggregate, String source, List<Association> associations) {
+		for (Association association : associations) {
+			addAssociationToList(aggregate, source, association.getDomainObjectType(), association.getDescription());
 		}
 	}
 
-	private void addDomainObjectReference2List(String sourceDomainObject, SimpleDomainObject targetDomainObject, String label, ClassRelationType type) {
-		if (this.domainObjects.contains(targetDomainObject)) {
-			UMLRelationship relationship = new UMLRelationship(sourceDomainObject, targetDomainObject.getName(), label, type);
-			if (!this.relationships.contains(relationship))
-				this.relationships.add(relationship);
+	private void processReferencesAsAssociations(Aggregate aggregate, SimpleDomainObject sourceDomainObject, List<Reference> references) {
+		for (Reference reference : references) {
+			Multiplicity multiplicityTarget = getMultiplicityReference(reference);
+			addNavigableAssociationToList(aggregate, sourceDomainObject.getName(), reference.getDomainObjectType(), getLabel(reference.getAssociationLabel(), reference.getName()), multiplicityTarget);
 		}
+	}
+
+	private Multiplicity getMultiplicityReference(Reference reference) {
+		Multiplicity result = new Multiplicity(1, 1);
+
+		if (reference.getCollectionType() != null && reference.getCollectionType() != CollectionType.NONE)
+			result = new Multiplicity(0, Multiplicity.STAR);
+		
+		if (reference.getSize() != null && !reference.getSize().equals("")) {
+			String size = reference.getSize();
+			String[] parts = size.split(",");
+			for (String part : parts) {
+				if (part.startsWith("min=")) {
+					Integer min = parseIntLax(part.substring(4));
+					if (min != null)
+						result = result.withMin(min);
+				}
+				if (part.startsWith("max=")) {
+					Integer max = parseIntLax(part.substring(4));
+					if (max != null)
+						result = result.withMax(max);
+				}
+			}
+		}
+		if (reference.isNullable())
+			result = result.withMin(0);
+
+		return result;
+	}
+
+	private Integer parseIntLax(String str) {
+		try {
+			return Integer.parseInt(str);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private String getLabel(String label, String name) {
+		if (label != null && !"".equals(label))
+			return label;
+		else
+			return name;
+	}
+
+	private void addNavigableAssociationToList(Aggregate aggregate, String source, SimpleDomainObject targetDomainObject, String label, Multiplicity multiplicityTarget) {
+		if (this.domainObjects.contains(targetDomainObject)) {
+			String target = targetDomainObject.getName();
+			AssociationInfo info = createOrGetAssociationInList(aggregate, source, target, label);
+			info.setNavigability(source, target);
+			if (info.getMultiplicity(source) == null)
+				info.setMultiplicity(source, new Multiplicity(1, 1));
+			if (info.getMultiplicity(target) == null || info.getMultiplicity(target).getMin() == 1)
+				info.setMultiplicity(target, multiplicityTarget);
+		}
+	}
+
+	private void addAssociationToList(Aggregate aggregate, String source, SimpleDomainObject targetDomainObject, String label) {
+		if (this.domainObjects.contains(targetDomainObject)) {
+			String target = targetDomainObject.getName();
+			createOrGetAssociationInList(aggregate, source, target, label);
+		}
+	}
+
+	private AssociationInfo createOrGetAssociationInList(Aggregate aggregate, String source, String target, String label) {
+		AssociationLink link = new AssociationLink(source, target, label);
+		if (!associationInfos.containsKey(link)) {
+			AssociationInfo info = new AssociationInfo(link);
+			if (aggregateContainsDomainObject(aggregate, source))
+				info.setAggregateSource(aggregate.getName());
+			if (aggregateContainsDomainObject(aggregate, target))
+				info.setAggregateTarget(aggregate.getName());
+			associationInfos.put(link, info);				 
+		}
+		return associationInfos.get(link);
+	}
+
+	private boolean aggregateContainsDomainObject(Aggregate aggregate, String source) {
+		if (aggregate != null) {
+			return aggregate.getDomainObjects()
+				.stream()
+				.filter((obj) -> obj.getName().equals(source))
+				.findAny()
+				.isPresent();
+		}
+
+		return false;
 	}
 
 	private void addExtensionToList(String sourceDomainObject, SimpleDomainObject extendedDomainObject) {
@@ -240,11 +337,11 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 		if (returnType == null)
 			returnTypeAsString = "void";
 		else
-			returnTypeAsString = getComplexMethodTypeAsString(returnType, objectName, operationName);
+			returnTypeAsString = getComplexMethodTypeAsString(returnType);
 		sb.append(returnTypeAsString).append(" ").append(operationName).append("(");
 		List<String> parameterStrings = Lists.newArrayList();
 		for (Parameter parameter : parameters) {
-			String parameterType = getComplexMethodTypeAsString(parameter.getParameterType(), objectName, operationName);
+			String parameterType = getComplexMethodTypeAsString(parameter.getParameterType());
 			parameterStrings.add(parameterType + " " + parameter.getName());
 		}
 		if (!parameterStrings.isEmpty())
@@ -253,11 +350,10 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 		linebreak();
 	}
 
-	private String getComplexMethodTypeAsString(ComplexType type, String containingObjectName4References, String methodName) {
+	private String getComplexMethodTypeAsString(ComplexType type) {
 		String genericType = "Object";
 		if (type.getDomainObjectType() != null) {
 			genericType = type.getDomainObjectType().getName();
-			addDomainObjectReference2List(containingObjectName4References, type.getDomainObjectType(), methodName, ClassRelationType.DEFAULT);
 		} else {
 			genericType = type.getType();
 		}
@@ -274,18 +370,74 @@ abstract public class AbstractPlantUMLClassDiagramCreator<T extends EObject> ext
 	}
 
 	protected void printReferences(int indentation) {
-		for (UMLRelationship reference : relationships) {
+		associationInfos.forEach((link, info) -> {
+			boolean suppressMultiplicity = 
+				info.getMultiplicityFirstParticipant() != null &&
+				info.getMultiplicityFirstParticipant().isConstant(1) && 
+				info.getMultiplicitySecondParticipant() != null &&
+				info.getMultiplicitySecondParticipant().isConstant(1);
+
 			printIndentation(indentation);
-			sb.append(reference.getSource()).append(" ").append(reference.getSymbol()).append(" ").append(reference.getTarget());
-			if (!"".equals(reference.getLabel()))
-				sb.append(" : ").append(reference.getLabel());
-			linebreak();
-		}
+
+			// e.g.: first
+			sb.append(link.getFirstParticipant()).append(" ");			
+
+			// e.g.: first "1"
+			if (info.getMultiplicityFirstParticipant() != null && !suppressMultiplicity)
+				sb.append("\"").append(printMultiplicity(info.getMultiplicityFirstParticipant())).append("\"").append(" ");	
+
+			// e.g.: first "1" *-->
+			printLink(info);
+
+			// e.g.: first "1" *--> "*"
+			if (info.getMultiplicitySecondParticipant() != null && !suppressMultiplicity)
+				sb.append("\"").append(printMultiplicity(info.getMultiplicitySecondParticipant())).append("\"").append(" ");
+
+			// e.g.: first "1" *--> "*" second
+			sb.append(link.getSecondParticipant());
+
+			// e.g.: first "1" *--> "*" second : something
+			if (!"".equals(link.getLabel()))
+		 		sb.append(" : ").append(link.getLabel());
+		 	linebreak();
+		});
+
 		for (UMLRelationship extension : extensions) {
 			printIndentation(indentation);
 			sb.append(extension.getSource()).append(" ").append(extension.getSymbol()).append(" ").append(extension.getTarget());
 			linebreak();
 		}
+	}
+
+	private void printLink(AssociationInfo info) {
+		boolean multFirstIsMany = info.getMultiplicityFirstParticipant() != null && info.getMultiplicityFirstParticipant().getMax() > 1,
+				multSecondIsMany = info.getMultiplicitySecondParticipant() != null && info.getMultiplicitySecondParticipant().getMax() > 1;
+		String aggregationSymbol = (info.getAggregateSource().equals(info.getAggregateTarget())) ? "*" : "o";
+
+		if (multSecondIsMany && !multFirstIsMany)
+			sb.append(aggregationSymbol);
+		else if (info.getIsFirstNavigableFromSecond())
+			sb.append("<");
+
+		sb.append("--");
+
+		if (multFirstIsMany && !multSecondIsMany) {
+			sb.append(aggregationSymbol); 
+		} else if (info.getIsSecondNavigableFromFirst())
+			sb.append(">");							
+		sb.append(" ");
+	}
+
+	private String printMultiplicity(Multiplicity multiplicity) {
+		int min = multiplicity.getMin(), max = multiplicity.getMax();
+
+		if (min == max)
+			return Integer.toString(min);
+		
+		if (min == 0 && max == Multiplicity.STAR)
+			return "*";
+
+		return Integer.toString(min) + ".." + Integer.toString(max);
 	}
 
 	protected void printIndentation(int amount) {

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AssociationInfo.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AssociationInfo.java
@@ -1,0 +1,76 @@
+package org.contextmapper.dsl.generator.plantuml;
+
+public class AssociationInfo {
+    private AssociationLink link;
+    private Multiplicity multiplicityFirstParticipant;
+    private Multiplicity multiplicitySecondParticipant;
+    private boolean secondIsNavigableFromFirst;
+    private boolean firstIsNavigableFromSecond;
+    private String aggregateSource;
+    private String aggregateTarget;
+
+    AssociationInfo(AssociationLink link) {
+        this.link = link;
+        this.multiplicityFirstParticipant = null;
+        this.multiplicitySecondParticipant = null;
+        this.secondIsNavigableFromFirst = false;
+        this.firstIsNavigableFromSecond = false;
+    }
+
+    public boolean getIsSecondNavigableFromFirst() {
+        return secondIsNavigableFromFirst;
+    }
+
+    public boolean getIsFirstNavigableFromSecond() {
+        return firstIsNavigableFromSecond;
+    }
+
+    public void setNavigability(String source, String target) {
+        // Note that self-reference becomes bi-directional
+        if (link.getFirstParticipant().equals(source) && link.getSecondParticipant().equals(target))
+            this.secondIsNavigableFromFirst = true;
+        if (link.getSecondParticipant().equals(source) && link.getFirstParticipant().equals(target))
+            this.firstIsNavigableFromSecond = true;
+    }
+
+    public Multiplicity getMultiplicityFirstParticipant() {
+        return multiplicityFirstParticipant;
+    }
+
+    public Multiplicity getMultiplicitySecondParticipant() {
+        return multiplicitySecondParticipant;
+    }
+
+    public void setMultiplicity(String participant, Multiplicity multiplicity) {
+        if (link.isSelfReference())
+            return;
+
+        if (participant.equals(link.getFirstParticipant()))
+            this.multiplicityFirstParticipant = multiplicity.clone();
+        else
+            this.multiplicitySecondParticipant = multiplicity.clone();
+    }
+
+    public Multiplicity getMultiplicity(String participant) {
+        if (participant.equals(link.getFirstParticipant()))
+            return multiplicityFirstParticipant;
+        else
+            return multiplicitySecondParticipant;
+    }
+
+    public String getAggregateSource() {
+        return aggregateSource;
+    }
+
+    public String getAggregateTarget() {
+        return aggregateTarget;
+    }
+
+    public void setAggregateSource(String aggregateSource) {
+        this.aggregateSource = aggregateSource;
+    }
+
+    public void setAggregateTarget(String aggregateTarget) {
+        this.aggregateTarget = aggregateTarget;
+    }
+}

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AssociationLink.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AssociationLink.java
@@ -1,63 +1,59 @@
 package org.contextmapper.dsl.generator.plantuml;
 
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
 public class AssociationLink {
-    private String participant1;
-    private String participant2;
-    private String label;
+	private String participant1;
+	private String participant2;
+	private String label;
 
-    public AssociationLink(String participant1, String participant2, String label)
-    {
-            this.participant1 = participant1;
-            this.participant2 = participant2;
-            this.label = label;
-    }   
+	public AssociationLink(String participant1, String participant2, String label) {
+		this.participant1 = participant1;
+		this.participant2 = participant2;
+		this.label = label;
+	}
 
-    public String getFirstParticipant() {
-        return participant1;
-    }
+	public String getFirstParticipant() {
+		return participant1;
+	}
 
-    public String getSecondParticipant() {
-        return participant2;
-    }
+	public String getSecondParticipant() {
+		return participant2;
+	}
 
-    public String getLabel() {
-        return label;
-    }
+	public String getLabel() {
+		return label;
+	}
 
-    public boolean equals(Object obj) {
-        if (this==obj)
-            return true;
-        if((obj == null) || (obj.getClass() != this.getClass()))
-            return false;            
-        AssociationLink other = (AssociationLink)obj;
+	@Override
+	public int hashCode() {
+		return Objects.hash(label, createParticipantSet(this));
+	}
 
-        String thisP1, thisP2, otherP1, otherP2;
-        if (participant1.compareTo(participant2) < 0)
-        {
-            thisP1 = this.participant1;
-            thisP2 = this.participant2;
-        } else {
-            thisP1 = this.participant2;
-            thisP2 = this.participant1;
-        }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		AssociationLink other = (AssociationLink) obj;
+		return Objects.equals(label, other.label)
+				&& Objects.equals(createParticipantSet(this), createParticipantSet(other));
+	}
 
-        if (other.participant1.compareTo(other.participant2) < 0)
-        {
-            otherP1 = other.participant1;
-            otherP2 = other.participant2;
-        } else {
-            otherP1 = other.participant2;
-            otherP2 = other.participant1;
-        }
+	private Set<String> createParticipantSet(final AssociationLink association) {
+		Set<String> participants = Sets.newTreeSet();
+		participants.add(association.participant1);
+		participants.add(association.participant2);
+		return participants;
+	}
 
-        return thisP1.equals(otherP1) && thisP2.equals(otherP2) && this.label.equals(other.label);
-    }
-    
-    public int hashCode() {
-        return participant1.hashCode() + participant2.hashCode() + label.hashCode();
-    }
-
-    public boolean isSelfReference() {
-        return participant1.equals(participant2);
-    }
+	public boolean isSelfReference() {
+		return participant1.equals(participant2);
+	}
 }

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AssociationLink.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/AssociationLink.java
@@ -1,0 +1,63 @@
+package org.contextmapper.dsl.generator.plantuml;
+
+public class AssociationLink {
+    private String participant1;
+    private String participant2;
+    private String label;
+
+    public AssociationLink(String participant1, String participant2, String label)
+    {
+            this.participant1 = participant1;
+            this.participant2 = participant2;
+            this.label = label;
+    }   
+
+    public String getFirstParticipant() {
+        return participant1;
+    }
+
+    public String getSecondParticipant() {
+        return participant2;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public boolean equals(Object obj) {
+        if (this==obj)
+            return true;
+        if((obj == null) || (obj.getClass() != this.getClass()))
+            return false;            
+        AssociationLink other = (AssociationLink)obj;
+
+        String thisP1, thisP2, otherP1, otherP2;
+        if (participant1.compareTo(participant2) < 0)
+        {
+            thisP1 = this.participant1;
+            thisP2 = this.participant2;
+        } else {
+            thisP1 = this.participant2;
+            thisP2 = this.participant1;
+        }
+
+        if (other.participant1.compareTo(other.participant2) < 0)
+        {
+            otherP1 = other.participant1;
+            otherP2 = other.participant2;
+        } else {
+            otherP1 = other.participant2;
+            otherP2 = other.participant1;
+        }
+
+        return thisP1.equals(otherP1) && thisP2.equals(otherP2) && this.label.equals(other.label);
+    }
+    
+    public int hashCode() {
+        return participant1.hashCode() + participant2.hashCode() + label.hashCode();
+    }
+
+    public boolean isSelfReference() {
+        return participant1.equals(participant2);
+    }
+}

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/Multiplicity.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/Multiplicity.java
@@ -1,0 +1,39 @@
+package org.contextmapper.dsl.generator.plantuml;
+
+public class Multiplicity {
+    private int min;
+    private int max;
+    
+    public static int STAR = Integer.MAX_VALUE;
+
+    public Multiplicity(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    public Multiplicity withMin(int min)
+    {
+        return new Multiplicity(min, this.max);
+    }
+
+    public Multiplicity withMax(int max)
+    {
+        return new Multiplicity(this.min, max);
+    }
+
+    public Multiplicity clone() {
+        return new Multiplicity(this.min, this.max);
+    }
+
+    public boolean isConstant(int i) {
+        return min == i && max == i;
+    }
+}

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLAggregateClassDiagramCreator.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLAggregateClassDiagramCreator.java
@@ -20,13 +20,15 @@ import org.contextmapper.dsl.validation.ValidationMessages;
 import org.contextmapper.tactic.dsl.tacticdsl.SimpleDomainObject;
 import org.eclipse.xtext.EcoreUtil2;
 
+import java.util.HashMap;
+
 import com.google.common.collect.Lists;
 
 public class PlantUMLAggregateClassDiagramCreator extends AbstractPlantUMLClassDiagramCreator<Aggregate> implements PlantUMLDiagramCreator<Aggregate> {
 
 	@Override
 	protected void printDiagramContent(Aggregate aggregate) {
-		this.relationships = Lists.newArrayList();
+		this.associationInfos = new HashMap<>();
 		this.extensions = Lists.newArrayList();
 		this.domainObjects = EcoreUtil2.<SimpleDomainObject>getAllContentsOfType(aggregate, SimpleDomainObject.class);
 		if (this.domainObjects.size() <= 0) {

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLBoundedContextClassDiagramCreator.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLBoundedContextClassDiagramCreator.java
@@ -15,6 +15,7 @@
  */
 package org.contextmapper.dsl.generator.plantuml;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -39,7 +40,7 @@ public class PlantUMLBoundedContextClassDiagramCreator extends AbstractPlantUMLC
 
 	@Override
 	protected void printDiagramContent(BoundedContext boundedContext) {
-		this.relationships = Lists.newArrayList();
+		this.associationInfos = new HashMap<>();
 		this.extensions = Lists.newArrayList();
 		this.domainObjects = EcoreUtil2.<SimpleDomainObject>getAllContentsOfType(boundedContext, SimpleDomainObject.class);
 		if (this.domainObjects.size() <= 0) {

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLModuleClassDiagramCreator.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLModuleClassDiagramCreator.java
@@ -20,13 +20,15 @@ import org.contextmapper.dsl.validation.ValidationMessages;
 import org.contextmapper.tactic.dsl.tacticdsl.SimpleDomainObject;
 import org.eclipse.xtext.EcoreUtil2;
 
+import java.util.HashMap;
+
 import com.google.common.collect.Lists;
 
 public class PlantUMLModuleClassDiagramCreator extends AbstractPlantUMLClassDiagramCreator<SculptorModule> implements PlantUMLDiagramCreator<SculptorModule> {
 
 	@Override
 	protected void printDiagramContent(SculptorModule module) {
-		this.relationships = Lists.newArrayList();
+		this.associationInfos = new HashMap<>();
 		this.extensions = Lists.newArrayList();
 		this.domainObjects = EcoreUtil2.<SimpleDomainObject>getAllContentsOfType(module, SimpleDomainObject.class);
 		if (this.domainObjects.size() <= 0) {

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLSubdomainClassDiagramCreator.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/generator/plantuml/PlantUMLSubdomainClassDiagramCreator.java
@@ -20,6 +20,8 @@ import org.contextmapper.dsl.contextMappingDSL.Subdomain;
 import org.contextmapper.tactic.dsl.tacticdsl.SimpleDomainObject;
 import org.eclipse.xtext.EcoreUtil2;
 
+import java.util.HashMap;
+
 import com.google.common.collect.Lists;
 
 public class PlantUMLSubdomainClassDiagramCreator extends AbstractPlantUMLClassDiagramCreator<Subdomain> implements PlantUMLDiagramCreator<Subdomain> {
@@ -32,7 +34,7 @@ public class PlantUMLSubdomainClassDiagramCreator extends AbstractPlantUMLClassD
 
 	@Override
 	protected void printDiagramContent(Subdomain subdomain) {
-		this.relationships = Lists.newArrayList();
+		this.associationInfos = new HashMap<>();
 		this.extensions = Lists.newArrayList();
 		this.domainObjects = EcoreUtil2.<SimpleDomainObject>getAllContentsOfType(subdomain, SimpleDomainObject.class);
 

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/scoping/CMLScopingHelper.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/scoping/CMLScopingHelper.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 
 import org.contextmapper.dsl.contextMappingDSL.impl.BoundedContextImpl;
 import org.contextmapper.dsl.contextMappingDSL.impl.DomainImpl;
+import org.contextmapper.tactic.dsl.tacticdsl.Association;
 import org.contextmapper.tactic.dsl.tacticdsl.DomainObject;
 import org.contextmapper.tactic.dsl.tacticdsl.Reference;
 import org.eclipse.emf.ecore.EObject;
@@ -47,6 +48,17 @@ public class CMLScopingHelper {
 		if (isPartOfBoundedContext(reference)) {
 			return filterScope(existingScope, (ieoDesc) -> ieoDesc.getEObjectOrProxy() instanceof DomainObject && isPartOfDomain(ieoDesc.getEObjectOrProxy()));
 		} else if (isPartOfDomain(reference)) {
+			return filterScope(existingScope, (ieoDesc) -> ieoDesc.getEObjectOrProxy() instanceof DomainObject && isPartOfBoundedContext(ieoDesc.getEObjectOrProxy()));
+		}
+		return existingScope;
+	}
+
+	public IScope reduceReferenceScope(IScope existingScope, Association association, EReference eReference) {
+		// domain objects in Domains shall not refer to domain objects in Bounded
+		// Contexts and vice versa:
+		if (isPartOfBoundedContext(association)) {
+			return filterScope(existingScope, (ieoDesc) -> ieoDesc.getEObjectOrProxy() instanceof DomainObject && isPartOfDomain(ieoDesc.getEObjectOrProxy()));
+		} else if (isPartOfDomain(association)) {
 			return filterScope(existingScope, (ieoDesc) -> ieoDesc.getEObjectOrProxy() instanceof DomainObject && isPartOfBoundedContext(ieoDesc.getEObjectOrProxy()));
 		}
 		return existingScope;

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/scoping/ContextMappingDSLScopeProvider.xtend
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/scoping/ContextMappingDSLScopeProvider.xtend
@@ -16,6 +16,7 @@
 package org.contextmapper.dsl.scoping
 
 import org.contextmapper.tactic.dsl.tacticdsl.Reference
+import org.contextmapper.tactic.dsl.tacticdsl.Association
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EReference
 import org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider
@@ -34,6 +35,10 @@ class ContextMappingDSLScopeProvider extends AbstractDeclarativeScopeProvider {
 	override getScope(EObject context, EReference reference) {
 		if (context instanceof Reference) {
 			return cmlScopingHelper.reduceReferenceScope(super.getScope(context, reference), context as Reference,
+				reference);
+		}
+		if (context instanceof Association) {
+			return cmlScopingHelper.reduceReferenceScope(super.getScope(context, reference), context as Association,
 				reference);
 		}
 		super.getScope(context, reference)

--- a/org.contextmapper.dsl/src/org/contextmapper/tactic/dsl/TacticDDDLanguage.xtext
+++ b/org.contextmapper.dsl/src/org/contextmapper/tactic/dsl/TacticDDDLanguage.xtext
@@ -56,7 +56,8 @@ Service :
   	 (subscribe=Subscribe)?
   	)
     (dependencies+=Dependency)*
-    (operations+=ServiceOperation)*
+    ((operations+=ServiceOperation) |
+     (associations+=Association))*
   "}")?;
 
 Resource :
@@ -224,7 +225,8 @@ Entity :
      ("belongsTo" (("@")?belongsTo=[DomainObject]))?)
     ((attributes+=Attribute) |
      (references+=Reference) |
-     (operations+=DomainObjectOperation))*
+     (operations+=DomainObjectOperation) |
+     (associations+=Association))*
     (repository=Repository)?
   "}")?;
 
@@ -252,7 +254,8 @@ ValueObject :
      ("belongsTo" (("@")?belongsTo=[DomainObject]))?)
     ((attributes+=Attribute) |
      (references+=Reference) |
-     (operations+=DomainObjectOperation))*
+     (operations+=DomainObjectOperation) |
+     (associations+=Association))*
     (repository=Repository)?
   "}")?;
 
@@ -280,7 +283,8 @@ DomainEvent :
     )
     ((attributes+=Attribute) |
      (references+=Reference) |
-     (operations+=DomainObjectOperation))*
+     (operations+=DomainObjectOperation) |
+     (associations+=Association))*
     (repository=Repository)?
   "}")?;
 
@@ -308,7 +312,8 @@ CommandEvent :
     )
     ((attributes+=Attribute) |
      (references+=Reference) |
-     (operations+=DomainObjectOperation))*
+     (operations+=DomainObjectOperation) |
+     (associations+=Association))*
     (repository=Repository)?
   "}")?;
 
@@ -319,7 +324,8 @@ Trait :
     ("hint" "=" hint=STRING)?
     ((attributes+=Attribute) |
      (references+=Reference) |
-     (operations+=DomainObjectOperation))*
+     (operations+=DomainObjectOperation) |
+     (associations+=Association))*
 
   "}")?;
 
@@ -359,7 +365,8 @@ BasicType :
     )
     ((attributes+=Attribute) |
      (references+=Reference) |
-     (operations+=DomainObjectOperation))*
+     (operations+=DomainObjectOperation) |
+     (associations+=Association))*
   "}")?;
 
 Attribute :
@@ -419,8 +426,15 @@ Reference :
      ("orderby" "=" orderBy=STRING)? &
      ((orderColumn?="orderColumn") ("=" orderColumnName=STRING)?)? &
      (oppositeHolder=OppositeHolder)?)
+     (ASC associationLabel=STRING)?
     (";")?;
 
+Association :
+  (doc=STRING)?
+  ASC (description=STRING)?
+    (("@")?domainObjectType=[SimpleDomainObject])
+    (";")?;
+    
 DtoAttribute :
   (doc=STRING)?
   (visibility=Visibility)? (collectionType=CollectionType"<")? type=Type (">")? name=ID
@@ -559,3 +573,6 @@ terminal OPPOSITE :
 
 terminal REF :
   ('-'|'reference');
+
+terminal ASC :
+  ('--'|'association');


### PR DESCRIPTION
This PR replaces [PR 319](https://github.com/ContextMapper/context-mapper-dsl/pull/319) and includes the improvements I suggested there:
* showing multiplicity on associations and allow setting multiplicity with the size property on a reference
* use composition for 1-many relation with entity within aggregate, aggregation for relation with entity outside aggregate
* allow adding "semantic" association useful for adding domain relations/constraints
* allow multiple associations between two entities (equality is defined on source, target and label)
* remove dependency associations since they clutter up the diagram (i.e. relations caused by references from Parameter or ReturnType of an operation)

This CML: 
```
BoundedContext CustomerManagementContext {
	
	Aggregate Customers {
		Entity Customer {
			aggregateRoot
			
            - @Address address nullable
			- List<@City> cities
			- List<@City> towns size="min=1,max=4"
			- List<@Order> orders
			- @Thing thing -- "things"

			* void anotherMethod(@Name name);
			* @ReturnTypeEntity createReturnTypeEntity();

			-- "lives at" @Address
			-- "uses >" @Name
			-- "creates >" @ReturnTypeEntity
		}
		
		Entity Address {
			- @City city
			String name
		}

		ValueObject City {
			String name
		}

        ValueObject Name {
            String first
            String last
        }

		Entity ReturnTypeEntity {
			int i
		}

		Entity ManyToManyFirst {
			- List<@ManyToManySecond> seconds -- "interact"
		}

		Entity ManyToManySecond {
			- List<@ManyToManyFirst> firsts	-- "interact"
		}

		Entity Thing {
			int i
		}
	}

	Aggregate Orders {
		Entity Order {
			String something
		}
	}
}
```

will produce [this diagram](https://www.plantuml.com/plantuml/uml/bLF1Rjim33tNNq5uXpP56op33eCH60soRfTr1PAWbs47LcOSBROKI7I7OEY_JvRYH74EJIyoH3u-ajPxTvRHS5DNIMBNKctGO0r2rnkjIF6SjnM1otvAaWsADPO4wUMqiQnhClOI9cLfg4Ic5CRZ6Gb6LLQKv_0lkH0LMWiTsEMl9ZSVbiibFdyP70fXfZM7Wej9KHYozjV7uN3q6p3SNFo7j3oUIjxc82HBwiLO_rNxqACfoEIWsqyRNAoaAe7RqzrUj2m0bUOLcGVYbIwkVc9DeDmnSFaPSMFKOhkXUyME78GXPEg7hnpsjTjmDtMxuFtDLpJhEU5tGwG64D2xxUPit12-bRjDFRix8YOVSpHFFPedh1g2n-S_9FYKB2BmkxoBO2cDvSFLiN34rz_xpHsbOf0HmGEgxKAtvxUsqPlr_WaFHNCIMXKvMF-r4N4VyrvcFquUrezvlLpEN_CrieLNtbcUyCXpzM9rJLw-eL-djjlRFEWb2ohQ-omTfJwPjYvAeSDddP_sI8UAifLy8Gl8nqJNdcaq77vEksxURSSexL7NwMwnh7DVr2dV_TaiMF4e5sIRGMF9GfxqDTCIZxiE9--UWLHC1iNfvBuY-acIZjgUgZiBTlTJ9CaTgQAfg_y0):
![bLF1Rjim33tNNq5uXpP56op33eCH60soRfTr1PAWbs47LcOSBROKI7I7OEY_JvRYH74EJIyoH3u-ajPxTvRHS5DNIMBNKctGO0r2rnkjIF6SjnM1otvAaWsADPO4wUMqiQnhClOI9cLfg4Ic5CRZ6Gb6LLQKv_0lkH0LMWiTsEMl9ZSVbiibFdyP70fXfZM7Wej9KHYozjV7uN3q6p3SNFo7j3](https://user-images.githubusercontent.com/825152/160350495-397bb5f9-3fc6-48bb-a933-5a28ee2b5142.png)

